### PR TITLE
README.rst: fix usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Usage
 -----
 Print your current data
 
-    pylink -u <USERNAME> -p <PASSWORD>
+    python -m pylinky -u <USERNAME> -p <PASSWORD>
 
 Dev env
 -------


### PR DESCRIPTION
The project does not provide any program named `pylink`.