### PR TITLE
Handle if no data in format_data

### DIFF
--- a/pylinky/client.py
+++ b/pylinky/client.py
@@ -129,7 +129,7 @@ class LinkyClient(object):
         result = []
 
         # Prevent from non existing data yet
-        if not data:
+        if not data or not data.get("data"):
             return []
 
         period_type = data['period_type']


### PR DESCRIPTION
This case could be possible if hour consumption is not activated in Enedis (user validation is required)

![image](https://user-images.githubusercontent.com/6990995/55113692-3eeb1180-50e0-11e9-8672-a53a2f2509c6.png)

I'm using Home assistant and I have the following issue 

```
File "/usr/local/lib/python3.7/site-packages/homeassistant/components/sensor/linky.py", line 88, in update
    _LOGGER.debug(json.dumps(self._client.get_data(), indent=2))
  File "/usr/local/lib/python3.7/site-packages/pylinky/client.py", line 202, in get_data
    formatted_data[t] = self.format_data(self._data[t])
  File "/usr/local/lib/python3.7/site-packages/pylinky/client.py", line 142, in format_data
    start_date = datetime.datetime.strptime(data.get("periode").get("dateDebut"), "%d/%m/%Y").date()
AttributeError: 'NoneType' object has no attribute 'get'
```

Home assistant use pylinky in version 0.3.0 ([requirements](https://github.com/home-assistant/home-assistant/blob/master/requirements_all.txt#L1135))

I try to troubleshoot and I got the another error with version 0.3.1:

``` 
Traceback (most recent call last):
  File "./linky.py", line 15, in <module>
    print(json.dumps(client.get_data(), indent=2))
  File "C:\Python37\lib\site-packages\pylinky\client.py", line 201, in get_data
    formatted_data[t] = self.format_data(self._data[t])
  File "C:\Python37\lib\site-packages\pylinky\client.py", line 152, in format_data
    kwargs = {format_data: data.get('decalage') * inc}
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
```

As hour is not activated, I got the following result when trying to get hourly data 

```json
{"etat":{"valeur":"nonActive"},"graphe":{}}
```

I add a check to handle this case and it works now!